### PR TITLE
Add awtSCADA - browser SCADA with OPC UA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ _Implementations of server and client applications and other examples._
 - [opcua-skills/plug-and-produce](https://github.com/opcua-skills/plug-and-produce) - Plug-and-Produce System Architecture for Robotic Applications using OPC UA [proprietary]
 - [convertersystems/opc-ua-samples](https://github.com/convertersystems/opc-ua-samples) - Sample HMIs using OPC Unified Architecture (OPC UA) and Visual Studio. [MIT]
 - [opcua-machinery-client](https://github.com/AndreasHeine/opcua-machinery-client) - Client example showcaseing the OPC UA for Machinery from a data consumer perspective. [MIT]
-- [BitSCADA](https://github.com/larionovavi-stack/bitscada) - Browser-based SCADA/HMI with OPC UA, IEC 61850, Modbus TCP support. Runs from a single HTML file with Python gateway for real device connections.
+- [awtSCADA](https://github.com/larionovavi-stack/bitscada) - Browser-based SCADA/HMI with OPC UA, IEC 61850, Modbus TCP support. Runs from a single HTML file with Python gateway for real device connections.
 
 ## Gateways (OPC Classic)
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ _Implementations of server and client applications and other examples._
 - [opcua-skills/plug-and-produce](https://github.com/opcua-skills/plug-and-produce) - Plug-and-Produce System Architecture for Robotic Applications using OPC UA [proprietary]
 - [convertersystems/opc-ua-samples](https://github.com/convertersystems/opc-ua-samples) - Sample HMIs using OPC Unified Architecture (OPC UA) and Visual Studio. [MIT]
 - [opcua-machinery-client](https://github.com/AndreasHeine/opcua-machinery-client) - Client example showcaseing the OPC UA for Machinery from a data consumer perspective. [MIT]
-- [awtSCADA](https://github.com/larionovavi-stack/bitscada) - Browser-based SCADA/HMI with OPC UA, IEC 61850, Modbus TCP support. Runs from a single HTML file with Python gateway for real device connections.
+- [awtSCADA](https://github.com/larionovavi-stack/awtscada) - Browser-based SCADA/HMI with OPC UA, IEC 61850, Modbus TCP support. Runs from a single HTML file with Python gateway for real device connections.
 
 ## Gateways (OPC Classic)
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ _Implementations of server and client applications and other examples._
 - [opcua-skills/plug-and-produce](https://github.com/opcua-skills/plug-and-produce) - Plug-and-Produce System Architecture for Robotic Applications using OPC UA [proprietary]
 - [convertersystems/opc-ua-samples](https://github.com/convertersystems/opc-ua-samples) - Sample HMIs using OPC Unified Architecture (OPC UA) and Visual Studio. [MIT]
 - [opcua-machinery-client](https://github.com/AndreasHeine/opcua-machinery-client) - Client example showcaseing the OPC UA for Machinery from a data consumer perspective. [MIT]
+- [BitSCADA](https://github.com/larionovavi-stack/bitscada) - Browser-based SCADA/HMI with OPC UA, IEC 61850, Modbus TCP support. Runs from a single HTML file with Python gateway for real device connections.
 
 ## Gateways (OPC Classic)
 


### PR DESCRIPTION
## Addition

Added **[awtSCADA](https://github.com/larionovavi-stack/awtscada)** to the Server and client applications section.

awtSCADA is a browser-based SCADA/HMI system supporting OPC UA alongside IEC 61850 and Modbus TCP. It runs from a single HTML file with a Python gateway for real device connections via OPC UA client/server.

- Live Demo: https://larionovavi-stack.github.io/awtscada/
- Features: 53 function blocks, 65 graphic elements, REST API